### PR TITLE
Update `lambert_w` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 rustdoc-args = [ "--html-in-header", "katex-header.html", "--cfg", "docsrs"]
 
 [dependencies]
-lambert_w = "0.5.0"
+lambert_w = { version = "0.5.1", default-features = false, features = ["24bits","50bits","std"] }
 
 [dev-dependencies]
 peroxide = { version = "0.37", features = ["plot"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 rustdoc-args = [ "--html-in-header", "katex-header.html", "--cfg", "docsrs"]
 
 [dependencies]
-lambert_w = { version = "0.5.1", default-features = false, features = ["24bits","50bits","std"] }
+lambert_w = { version = "0.5.2", default-features = false, features = ["24bits","50bits","std"] }
 
 [dev-dependencies]
 peroxide = { version = "0.37", features = ["plot"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 rustdoc-args = [ "--html-in-header", "katex-header.html", "--cfg", "docsrs"]
 
 [dependencies]
-lambert_w = { version = "0.5.2", default-features = false, features = ["24bits","50bits","std"] }
+lambert_w = { version = "0.5.2", default-features = false, features = ["24bits", "50bits", "std"] }
 
 [dev-dependencies]
 peroxide = { version = "0.37", features = ["plot"] }


### PR DESCRIPTION
I made the `lambert_w` crate be `no_std` so that such projects can use it. When in `no_std` mode it uses the `libm` crate as a dependency, so this PR specifies the features of the `lambert_w` crate such that it does not use any dependencies, and uses the standard library like all the other functions in `puruspe`.

The end result is no changes for `puruspe` :P