### PR TITLE
Move dawson test

### DIFF
--- a/tests/dawson_test.rs
+++ b/tests/dawson_test.rs
@@ -1,9 +1,9 @@
-extern crate puruspe;
 use puruspe::dawson;
 
-fn main() {
+#[test]
+fn dawson_test() {
     let expected = 0.13818492867352312; // From Wolfram|Alpha
     let res = dawson(0.14);
     dbg!(expected, res);
-    assert!((expected - res).abs() < 1e-7);
+    assert!((expected - res).abs() < 1e-7); // Verify accuracy.
 }


### PR DESCRIPTION
This moves the test for Dawson's integral from
src/bin to a test module in the same file as the
function being tested.

I don't know if this is how you want the tests to be organized, but it seems to be standard practice in most crates. Personally, I like having tests right below the code they're testing.