### PR TITLE
Add gammp & invgammp tests

### DIFF
--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -135,7 +135,7 @@ fn gammpapprox(a: f64, x: f64, psig: IncGamma) -> f64 {
     }
 }
 
-/// Iunverse Incomplete Gamma function
+/// Inverse Incomplete Gamma function
 pub fn invgammp(p: f64, a: f64) -> f64 {
     let gln = ln_gamma(a);
     let a1 = a - 1f64;

--- a/tests/gammp_test.rs
+++ b/tests/gammp_test.rs
@@ -1,0 +1,33 @@
+use puruspe::{gammp, invgammp};
+
+#[test]
+fn gammp_test() {
+    let expected_1 = 0.05265301734; // ɣ(5,2)/Γ(5) according to Wolfram|Alpha.
+    let a = 5_f64;
+    let x = 2_f64;
+    let res_1 = gammp(a, x);
+    assert!((res_1 - expected_1).abs() < 1e-11);
+
+    let expected_2 = 0.96739453751; // Ditto.
+    let a = 0.8;
+    let x = 3_f64;
+    let res_2 = gammp(a, x);
+    assert!((res_2 - expected_2).abs() < 1e-11);
+}
+
+#[test]
+fn invgammp_test() {
+    // Invert the first test above.
+    let expected_1 = 2_f64;
+    let a = 5_f64;
+    let p = 0.05265301734371115;
+    let res_1 = invgammp(p, a);
+    assert!((res_1 - expected_1).abs() < 1e-10);
+
+    // Invert the second test.
+    let expected_2 = 3_f64;
+    let a = 0.8;
+    let p = 0.96739453751512363;
+    let res_2 = invgammp(p, a);
+    assert!((res_2 - expected_2).abs() < 1e-10);
+}


### PR DESCRIPTION
This adds integration tests for the gammp &
invgammp functions, and fixes a minor typo
in invgammp's documentation comment.

I did not delete the old-style tests in the bin directory with this commit—you'll have to decide whether these tests' coverage is sufficient. I did verify that they all pass.