### PR TITLE
Separate the test of `lambert_w0` close to the domain, decrease `epsilon` on the other tests.

### DIFF
--- a/scripts/lambert_w_table.py
+++ b/scripts/lambert_w_table.py
@@ -12,8 +12,8 @@ x_values = [
     1e5, 1e10  # Very large values
 ]
 
-#                  Test close to the edge of the domain                                                 Also test massive input
-lambert_w0_table = [(-0.36787944117144233, -1.0)] + [(x, np.real(lambertw(x))) for x in x_values] + [(1e308, np.real(lambertw(1e308)))]
+#                                                                   Also test massive input
+lambert_w0_table = [(x, np.real(lambertw(x))) for x in x_values] + [(1e308, np.real(lambertw(1e308)))]
 
 print("const LAMBERT_W0_TABLE: [(f64, f64); {}] = [".format(len(lambert_w0_table)))
 for x, y in lambert_w0_table:
@@ -36,3 +36,6 @@ print("const LAMBERT_WM1_TABLE: [(f64, f64); {}] = [".format(len(lambert_wm1_tab
 for x, y in lambert_wm1_table:
     print("    ({:.14e}, {:.14e}),".format(x, y))
 print("];")
+
+# Test close to the edge of the domain
+print("const DOMAIN_EDGE: (f64, f64) = (-0.36787944117144233, -1.0);")

--- a/tests/lambert_w_test.rs
+++ b/tests/lambert_w_test.rs
@@ -60,6 +60,8 @@ fn test_lambert_w0() {
 fn test_lambert_wm1() {
     assert!(lambert_wm1(-1.0).is_nan());
     assert!(sp_lambert_wm1(-1.0).is_nan());
+    assert_abs_diff_eq!(lambert_wm1(DOMAIN_EDGE.0), DOMAIN_EDGE.1, epsilon = 1e-7);
+    assert_abs_diff_eq!(sp_lambert_wm1(DOMAIN_EDGE.0), DOMAIN_EDGE.1, epsilon = 1e-7);
     for (x, y) in LAMBERT_WM1_TABLE {
         let epsilon = f64::EPSILON + 1e-14 * lambert_wm1(x).abs().min(y.abs());
         let sp_epsilon = f64::EPSILON + 1e-7 * sp_lambert_wm1(x).abs().min(y.abs());

--- a/tests/lambert_w_test.rs
+++ b/tests/lambert_w_test.rs
@@ -1,8 +1,7 @@
 use approx::assert_abs_diff_eq;
 use puruspe::*;
 
-const LAMBERT_W0_TABLE: [(f64, f64); 21] = [
-    (-3.67879441171442e-01, -1.00000000000000e+00),
+const LAMBERT_W0_TABLE: [(f64, f64); 20] = [
     (1.00000000000000e-01, 9.12765271608623e-02),
     (2.00000000000000e-01, 1.68915973499110e-01),
     (5.00000000000000e-01, 3.51733711249196e-01),
@@ -41,12 +40,15 @@ const LAMBERT_WM1_TABLE: [(f64, f64); 13] = [
     (-1.00000000000000e-100, -2.35721158875685e+02),
 ];
 
+const DOMAIN_EDGE: (f64, f64) = (-0.36787944117144233, -1.0);
+
 #[test]
 fn test_lambert_w0() {
     assert!(lambert_w0(-1.0).is_nan());
     assert!(sp_lambert_w0(-1.0).is_nan());
+    assert_abs_diff_eq!(lambert_w0(DOMAIN_EDGE.0), DOMAIN_EDGE.1, epsilon = 1e-7);
     for (x, y) in LAMBERT_W0_TABLE {
-        let epsilon = f64::EPSILON + 1e-7 * lambert_w0(x).abs().min(y.abs());
+        let epsilon = f64::EPSILON + 1e-14 * lambert_w0(x).abs().min(y.abs());
         let sp_epsilon = f64::EPSILON + 1e-6 * sp_lambert_w0(x).abs().min(y.abs());
         assert_abs_diff_eq!(lambert_w0(x), y, epsilon = epsilon);
         assert_abs_diff_eq!(sp_lambert_w0(x), y, epsilon = sp_epsilon);

--- a/tests/lambert_w_test.rs
+++ b/tests/lambert_w_test.rs
@@ -47,6 +47,7 @@ fn test_lambert_w0() {
     assert!(lambert_w0(-1.0).is_nan());
     assert!(sp_lambert_w0(-1.0).is_nan());
     assert_abs_diff_eq!(lambert_w0(DOMAIN_EDGE.0), DOMAIN_EDGE.1, epsilon = 1e-7);
+    assert_abs_diff_eq!(sp_lambert_w0(DOMAIN_EDGE.0), DOMAIN_EDGE.1, epsilon = 1e-7);
     for (x, y) in LAMBERT_W0_TABLE {
         let epsilon = f64::EPSILON + 1e-14 * lambert_w0(x).abs().min(y.abs());
         let sp_epsilon = f64::EPSILON + 1e-6 * sp_lambert_w0(x).abs().min(y.abs());

--- a/tests/lambert_w_test.rs
+++ b/tests/lambert_w_test.rs
@@ -60,7 +60,7 @@ fn test_lambert_w0() {
 fn test_lambert_wm1() {
     assert!(lambert_wm1(-1.0).is_nan());
     assert!(sp_lambert_wm1(-1.0).is_nan());
-    assert_abs_diff_eq!(lambert_wm1(DOMAIN_EDGE.0), DOMAIN_EDGE.1, epsilon = 1e-7);
+    assert_abs_diff_eq!(lambert_wm1(DOMAIN_EDGE.0), DOMAIN_EDGE.1, epsilon = 1e-14);
     assert_abs_diff_eq!(sp_lambert_wm1(DOMAIN_EDGE.0), DOMAIN_EDGE.1, epsilon = 1e-7);
     for (x, y) in LAMBERT_WM1_TABLE {
         let epsilon = f64::EPSILON + 1e-14 * lambert_wm1(x).abs().min(y.abs());


### PR DESCRIPTION
Since `lambert_w0` is less accurate just at the beginning of its domain I have separated out that test, and reduced the size of the `epsilon` in the other tests of `lambert_w0` to 1e-14.

This means we can demonstrate the accuracy of the function in the rest of its domain while I see if I can improve the accuracy close to -1/e in future updates of `lambert_w`.