### PR TITLE
Add panics section to the docstring of panicing functions.

### DIFF
--- a/src/bessel.rs
+++ b/src/bessel.rs
@@ -225,6 +225,11 @@ pub fn Kn(n: u32, x: f64) -> f64 {
 /// - `Y_nu(x)` - Bessel function of the second kind
 /// - `J_nu'(x)` - Derivative of the Bessel function of the first kind
 /// - `Y_nu'(x)` - Derivative of the Bessel function of the second kind
+/// 
+/// # Panics
+/// 
+/// Panics if `x` ≤ 0 or if `nu` < 0. 
+/// Also panics if `x` is too large or if the function fails to converge.
 pub fn besseljy(nu: f64, x: f64) -> (f64, f64, f64, f64) {
     const MAXIT: usize = 10000;
     const EPS: f64 = f64::EPSILON;
@@ -565,6 +570,11 @@ impl_cached_bessel_convenience_functions!(CachedBesselJY, (f64, f64, f64, f64));
 /// * `K_nu(x)` - Modified Bessel function of the second kind
 /// * `I_nu'(x)` - Derivative of the modified Bessel function of the first kind
 /// * `K_nu'(x)` - Derivative of the modified Bessel function of the second kind
+/// 
+/// # Panics
+/// 
+/// Panics if `x` ≤ 0 or if `nu` < 0. 
+/// Also panics if `x` is too large or if the function fails to converge.
 pub fn besselik(nu: f64, x: f64) -> (f64, f64, f64, f64) {
     const MAXIT: usize = 10000;
     const EPS: f64 = f64::EPSILON;

--- a/src/beta.rs
+++ b/src/beta.rs
@@ -50,6 +50,10 @@ pub fn beta(z: f64, w: f64) -> f64 {
 /// # Returns
 ///
 /// The value of the regularized incomplete beta function $I_x(a,b)$
+/// 
+/// # Panics
+/// 
+/// Panics if `a` ≤ 0, if `b` ≤ 0 or if x is not in the range `0..=1`.
 pub fn betai(a: f64, b: f64, x: f64) -> f64 {
     assert!(a > 0f64 && b > 0f64, "Bad a or b in routine betai");
     assert!(x >= 0f64 && x <= 1f64, "Bad x in routine betai");

--- a/src/error.rs
+++ b/src/error.rs
@@ -137,6 +137,10 @@ const COF: [f64; 28] = [
 ];
 
 /// Chebyshev coefficients
+/// 
+/// # Panics
+/// 
+/// Panics if `z` < 0.
 fn erfccheb(z: f64) -> f64 {
     let mut d = 0f64;
     let mut dd = 0f64;

--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -86,6 +86,10 @@ pub fn gamma(z: f64) -> f64 {
 /// # Returns
 ///
 /// The value of P(a,x)
+/// 
+/// # Panics
+/// 
+/// Panics if `x` < 0 or if `a` ≤ 0.
 pub fn gammp(a: f64, x: f64) -> f64 {
     assert!(x >= 0f64 && a > 0f64, "Bad args in gammp");
     if x == 0f64 {
@@ -118,6 +122,10 @@ pub fn gammp(a: f64, x: f64) -> f64 {
 /// # Returns
 ///
 /// The value of Q(a,x)
+/// 
+/// # Panics
+/// 
+/// Panics if `x` < 0 or if `a` ≤ 0
 pub fn gammq(a: f64, x: f64) -> f64 {
     assert!(x >= 0f64 && a > 0f64, "Bad args in gammp");
     if x == 0f64 {
@@ -236,6 +244,10 @@ fn gammpapprox(a: f64, x: f64, psig: IncGamma) -> f64 {
 /// # Returns
 ///
 /// The value of x for which P(a,x) = p
+/// 
+/// # Panics
+/// 
+/// Panics if `a` ≤ 0.
 pub fn invgammp(p: f64, a: f64) -> f64 {
     let gln = ln_gamma(a);
     let a1 = a - 1f64;


### PR DESCRIPTION
I took the liberty of adding a `# Panics` section to the functions that can panic. I am not sure if I got all of them. I especially might have missed those without an assert or panic in the code, but that call other functions that can panic.