### PR TITLE
Update `lambert_w` to version 1.0.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 rustdoc-args = [ "--html-in-header", "katex-header.html", "--cfg", "docsrs"]
 
 [dependencies]
-lambert_w = { version = "0.5.2", default-features = false, features = ["24bits", "50bits", "std"] }
+lambert_w = { version = "1.0.0", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 peroxide = { version = "0.37", features = ["plot"] }


### PR DESCRIPTION
I made the feature API of the `lambert_w` crate simpler and stabilized it. This PR updates the dependency to the stable version.