### PR TITLE
Simplify Lambert W test code and don't depend on a specific patch version of `lambert_w`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 rustdoc-args = ["--html-in-header", "katex-header.html", "--cfg", "docsrs"]
 
 [dependencies]
-lambert_w = { version = "1.0.11", default-features = false, features = ["std"] }
+lambert_w = { version = "1.0.12", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 peroxide = { version = "0.39", features = ["plot"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 rustdoc-args = ["--html-in-header", "katex-header.html", "--cfg", "docsrs"]
 
 [dependencies]
-lambert_w = { version = "1.0.0", default-features = false, features = ["std"] }
+lambert_w = { version = "1.0.9", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 peroxide = { version = "0.39", features = ["plot"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 rustdoc-args = ["--html-in-header", "katex-header.html", "--cfg", "docsrs"]
 
 [dependencies]
-lambert_w = { version = "1.0.13", default-features = false, features = ["std"] }
+lambert_w = { version = "1.0.14", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 peroxide = { version = "0.39", features = ["plot"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 rustdoc-args = ["--html-in-header", "katex-header.html", "--cfg", "docsrs"]
 
 [dependencies]
-lambert_w = { version = "1.0.12", default-features = false, features = ["std"] }
+lambert_w = { version = "1.0.13", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 peroxide = { version = "0.39", features = ["plot"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 rustdoc-args = ["--html-in-header", "katex-header.html", "--cfg", "docsrs"]
 
 [dependencies]
-lambert_w = { version = "1.0.14", default-features = false, features = ["std"] }
+lambert_w = { version = "1.0", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 peroxide = { version = "0.39", features = ["plot"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 rustdoc-args = ["--html-in-header", "katex-header.html", "--cfg", "docsrs"]
 
 [dependencies]
-lambert_w = { version = "1.0.10", default-features = false, features = ["std"] }
+lambert_w = { version = "1.0.11", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 peroxide = { version = "0.39", features = ["plot"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 rustdoc-args = ["--html-in-header", "katex-header.html", "--cfg", "docsrs"]
 
 [dependencies]
-lambert_w = { version = "1.0.9", default-features = false, features = ["std"] }
+lambert_w = { version = "1.0.10", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 peroxide = { version = "0.39", features = ["plot"] }

--- a/tests/lambert_w_test.rs
+++ b/tests/lambert_w_test.rs
@@ -56,6 +56,8 @@ fn test_lambert_w0() {
     }
     assert_eq!(lambert_w0(f64::INFINITY), f64::INFINITY);
     assert_eq!(sp_lambert_w0(f64::INFINITY), f64::INFINITY);
+    assert!(lambert_w0(f64::NAN).is_nan());
+    assert!(sp_lambert_w0(f64::NAN).is_nan());
 }
 
 #[test]
@@ -72,4 +74,6 @@ fn test_lambert_wm1() {
         assert_relative_eq!(lambert_wm1(x), y, max_relative = 1e-14);
         assert_relative_eq!(sp_lambert_wm1(x), y, max_relative = 1e-7);
     }
+    assert!(lambert_wm1(f64::NAN).is_nan());
+    assert!(sp_lambert_wm1(f64::NAN).is_nan());
 }

--- a/tests/lambert_w_test.rs
+++ b/tests/lambert_w_test.rs
@@ -1,4 +1,4 @@
-use approx::assert_abs_diff_eq;
+use approx::{assert_abs_diff_eq, assert_relative_eq};
 use puruspe::*;
 
 const LAMBERT_W0_TABLE: [(f64, f64); 20] = [
@@ -51,10 +51,8 @@ fn test_lambert_w0() {
         epsilon = 1e-7
     );
     for (x, y) in LAMBERT_W0_TABLE {
-        let epsilon = f64::EPSILON + 1e-14 * lambert_w0(x).abs().min(y.abs());
-        let sp_epsilon = f64::EPSILON + 1e-6 * sp_lambert_w0(x).abs().min(y.abs());
-        assert_abs_diff_eq!(lambert_w0(x), y, epsilon = epsilon);
-        assert_abs_diff_eq!(sp_lambert_w0(x), y, epsilon = sp_epsilon);
+        assert_relative_eq!(lambert_w0(x), y, max_relative = 1e-14);
+        assert_relative_eq!(sp_lambert_w0(x), y, max_relative = 1e-7);
     }
     assert_eq!(lambert_w0(f64::INFINITY), f64::INFINITY);
     assert_eq!(sp_lambert_w0(f64::INFINITY), f64::INFINITY);
@@ -71,9 +69,7 @@ fn test_lambert_wm1() {
         epsilon = 1e-7
     );
     for (x, y) in LAMBERT_WM1_TABLE {
-        let epsilon = f64::EPSILON + 1e-14 * lambert_wm1(x).abs().min(y.abs());
-        let sp_epsilon = f64::EPSILON + 1e-7 * sp_lambert_wm1(x).abs().min(y.abs());
-        assert_abs_diff_eq!(lambert_wm1(x), y, epsilon = epsilon);
-        assert_abs_diff_eq!(sp_lambert_wm1(x), y, epsilon = sp_epsilon);
+        assert_relative_eq!(lambert_wm1(x), y, max_relative = 1e-14);
+        assert_relative_eq!(sp_lambert_wm1(x), y, max_relative = 1e-7);
     }
 }

--- a/tests/lambert_w_test.rs
+++ b/tests/lambert_w_test.rs
@@ -1,3 +1,5 @@
+use core::f64;
+
 use approx::assert_abs_diff_eq;
 use puruspe::*;
 
@@ -45,13 +47,19 @@ fn test_lambert_w0() {
     assert!(lambert_w0(-1.0).is_nan());
     assert!(sp_lambert_w0(-1.0).is_nan());
     assert_abs_diff_eq!(lambert_w0(BRANCH_POINT.0), BRANCH_POINT.1);
-    assert_abs_diff_eq!(sp_lambert_w0(BRANCH_POINT.0), BRANCH_POINT.1, epsilon = 1e-7);
+    assert_abs_diff_eq!(
+        sp_lambert_w0(BRANCH_POINT.0),
+        BRANCH_POINT.1,
+        epsilon = 1e-7
+    );
     for (x, y) in LAMBERT_W0_TABLE {
         let epsilon = f64::EPSILON + 1e-14 * lambert_w0(x).abs().min(y.abs());
         let sp_epsilon = f64::EPSILON + 1e-6 * sp_lambert_w0(x).abs().min(y.abs());
         assert_abs_diff_eq!(lambert_w0(x), y, epsilon = epsilon);
         assert_abs_diff_eq!(sp_lambert_w0(x), y, epsilon = sp_epsilon);
     }
+    assert_eq!(lambert_w0(f64::INFINITY), f64::INFINITY);
+    assert_eq!(sp_lambert_w0(f64::INFINITY), f64::INFINITY);
 }
 
 #[test]
@@ -59,7 +67,11 @@ fn test_lambert_wm1() {
     assert!(lambert_wm1(-1.0).is_nan());
     assert!(sp_lambert_wm1(-1.0).is_nan());
     assert_abs_diff_eq!(lambert_wm1(BRANCH_POINT.0), BRANCH_POINT.1);
-    assert_abs_diff_eq!(sp_lambert_wm1(BRANCH_POINT.0), BRANCH_POINT.1, epsilon = 1e-7);
+    assert_abs_diff_eq!(
+        sp_lambert_wm1(BRANCH_POINT.0),
+        BRANCH_POINT.1,
+        epsilon = 1e-7
+    );
     for (x, y) in LAMBERT_WM1_TABLE {
         let epsilon = f64::EPSILON + 1e-14 * lambert_wm1(x).abs().min(y.abs());
         let sp_epsilon = f64::EPSILON + 1e-7 * sp_lambert_wm1(x).abs().min(y.abs());

--- a/tests/lambert_w_test.rs
+++ b/tests/lambert_w_test.rs
@@ -1,5 +1,3 @@
-use core::f64;
-
 use approx::assert_abs_diff_eq;
 use puruspe::*;
 


### PR DESCRIPTION
This updates the dependency to the latest version, which includes a bugfix to the case when the input to the principal branch is infinite.

A user of `puruspe` would have gotten this bugfix automatically if they started their project after that version was published, or ever ran `cargo update`, but this way we know it's included.