### PR TITLE
Relax the tolerance for the relative error in the proptest of the Gamma function

### DIFF
--- a/tests/gamma_test.rs
+++ b/tests/gamma_test.rs
@@ -63,7 +63,7 @@ proptest! {
         let result = gamma(x);
         let expected = unsafe { tgamma(x) };
         let abs_eps = f64::EPSILON;
-        let rel_eps = 1e-10;
+        let rel_eps = 1e-9;
         assert_relative_eq!(result, expected, epsilon = abs_eps, max_relative = rel_eps);
     }
 


### PR DESCRIPTION
This seems to solve #42, as discussed there.

I ran the test suite several times on my personal PC, and it did not fail once.