### PR TITLE
Update the `lambert_w` dependency to version 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lambert_w"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1809c947da7b51d3b401028c81f6c58c1815c481786a3224a16c84e85a337dd4"
+dependencies = [
+ "num-complex",
+ "num-traits",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,7 +310,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0893368b28f4d37983703c75b345967d4c7184ae3306a6c048c0b711573ae3b"
 dependencies = [
- "lambert_w",
+ "lambert_w 1.2.34",
  "num-complex",
 ]
 
@@ -309,7 +319,7 @@ name = "puruspe"
 version = "0.4.4"
 dependencies = [
  "approx",
- "lambert_w",
+ "lambert_w 2.0.1",
  "num-complex",
  "peroxide",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 rustdoc-args = ["--html-in-header", "katex-header.html", "--cfg", "docsrs"]
 
 [dependencies]
-lambert_w = { version = "1.2.34", default-features = false, features = ["std"] }
+lambert_w = { version = "2.0.1", default-features = false, features = ["std"] }
 num-complex = { version = "0.4.6" }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use lambert_w::lambert_w as complex_lambert_w;
 /// Branch k of the complex valued Lambert W function computed on 64-bit floats with Halley's method.
 /// The return value is a tuple where the first element is the real part and the second element is the imaginary part.
 ///
-/// The function iterates until the current and previous iterations are within floating point epsilon, or it has iterated a maximum number of times
+/// The function iterates until the current and previous iterations are within floating point epsilon, or it has iterated a maximum number of times.
 ///
 /// This function may be slightly less accurate close to the branch cut at -1/e, as well as close to zero on branches other than k=0.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,22 @@
 // Import from other crates
 // =============================================================================
 // Lambert W functions
-pub use lambert_w::{lambert_w, lambert_w0, lambert_wm1, sp_lambert_w0, sp_lambert_wm1};
+pub use lambert_w::{lambert_w0, lambert_wm1, sp_lambert_w0, sp_lambert_wm1};
+use lambert_w::lambert_w as complex_lambert_w;
+
+// Re-export the complex Lambert W function as the version of `lambert_w` from version 2 of the crate takes an error tolerance,
+// which we set to floating point epsilon to match the API and performance of version 1.
+/// Branch k of the complex valued Lambert W function computed on 64-bit floats with Halley's method.
+/// The return value is a tuple where the first element is the real part and the second element is the imaginary part.
+///
+/// The function iterates until the current and previous iterations are within floating point epsilon, or it has iterated a maximum number of times
+///
+/// This function may be slightly less accurate close to the branch cut at -1/e, as well as close to zero on branches other than k=0.
+///
+/// If you know you want the principal or secondary branches where they are real-valued, take a look at the [`lambert_w0`] or [`lambert_wm1`] functions instead. They can be up to two orders of magnitude faster.
+pub fn lambert_w(k: i32, z_re: f64, z_im: f64) -> (f64, f64) {
+    complex_lambert_w(k, z_re, z_im, f64::EPSILON)
+}
 
 // =============================================================================
 // Export funcionts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ use lambert_w::lambert_w as complex_lambert_w;
 /// This function may be slightly less accurate close to the branch cut at -1/e, as well as close to zero on branches other than k=0.
 ///
 /// If you know you want the principal or secondary branches where they are real-valued, take a look at the [`lambert_w0`] or [`lambert_wm1`] functions instead. They can be up to two orders of magnitude faster.
+// We inline this function since it's just a trivial wrapper.
+#[inline]
 pub fn lambert_w(k: i32, z_re: f64, z_im: f64) -> (f64, f64) {
     complex_lambert_w(k, z_re, z_im, f64::EPSILON)
 }


### PR DESCRIPTION
I released version 2 of `lambert_w` to remove some long deprecated functionality.

Since I added an error tolerance to the iterating complex Lambert W function in version 2, I made a tiny wrapper here in `puruspe` that just calls the function with an error tolerance of `f64::EPSILON` which matches the behavior in version 1.